### PR TITLE
docs: reflect infra repo creation + Fargate decision

### DIFF
--- a/docs/aws-architecture.html
+++ b/docs/aws-architecture.html
@@ -51,7 +51,7 @@
       primitives without drowning in ops or blowing past free-tier (~$45–60/mo).</p>
     <div class="meta-row">
       <span class="chip">Status: Draft for review</span>
-      <span class="chip">Updated: 2026-06-20</span>
+      <span class="chip">Updated: 2026-06-28</span>
       <span class="chip"><a href="./index.html">← Docs index</a></span>
       <span class="chip"><a href="./delivery-plan.html">Delivery plan</a></span>
       <span class="chip"><a href="./repos.html">Repos</a></span>
@@ -232,11 +232,11 @@
       and consumed by each service via <code>workflow_call</code>, so a new Go service gets full CI in
       ~10 lines instead of copy-pasting a pipeline.</p>
     <ul>
-      <li><strong><code>go-ci.yml</code></strong> — lint (golangci-lint), build+vet, test, <strong>govulncheck</strong>,
+      <li><strong><code>go-ci</code></strong> — lint (golangci-lint), build+vet, test, <strong>govulncheck</strong>,
         and an optional integration pass. Inputs (<code>go-version-file</code>, <code>golangci-lint-version</code>,
         <code>run-integration</code>, <code>integration-packages</code>, …) carry sane defaults. Repo-specific jobs
         (e.g. <code>core</code>'s sqlc/mocks codegen-drift check) stay in the caller workflow alongside the <code>uses:</code> job.</li>
-      <li><strong><code>codeql.yml</code></strong> — CodeQL analysis of Go source <strong>and</strong> the repo's own
+      <li><strong><code>codeql</code></strong> — CodeQL analysis of Go source <strong>and</strong> the repo's own
         Actions workflows. The reusable workflow declares the permissions it needs; GitHub intersects them with what the caller grants.</li>
       <li><strong>Versioning:</strong> published behind a moving major tag <strong><code>@v1</code></strong> (immutable
         <code>v1.0.0</code> anchor underneath). Callers pin <code>…/go-ci.yml@v1</code>; patch/minor fixes move the

--- a/docs/aws-architecture.html
+++ b/docs/aws-architecture.html
@@ -51,7 +51,7 @@
       primitives without drowning in ops or blowing past free-tier (~$45–60/mo).</p>
     <div class="meta-row">
       <span class="chip">Status: Draft for review</span>
-      <span class="chip">Updated: 2026-06-28</span>
+      <span class="chip">Updated: 2026-06-29</span>
       <span class="chip"><a href="./index.html">← Docs index</a></span>
       <span class="chip"><a href="./delivery-plan.html">Delivery plan</a></span>
       <span class="chip"><a href="./repos.html">Repos</a></span>
@@ -226,24 +226,9 @@
       <li><strong>Merge → apply:</strong> download the <em>same</em> plan artifact and <code>tofu apply tfplan</code>. Gate prod behind a GitHub Environment with required reviewers; <code>concurrency</code> groups per env.</li>
       <li>Skip Atlantis/Spacelift/TFC for now (overkill for two people).</li>
     </ul>
-    <h3>Shared service CI — reusable workflows in <code>.github</code></h3>
-    <p>The infra <code>plan</code>/<code>apply</code> workflows above are repo-local. <strong>Service</strong> CI
-      (Go build/test/lint, CodeQL) is factored out once into the org repo <strong><code>fair-n-square-co/.github</code></strong>
-      and consumed by each service via <code>workflow_call</code>, so a new Go service gets full CI in
-      ~10 lines instead of copy-pasting a pipeline.</p>
-    <ul>
-      <li><strong><code>go-ci</code></strong> — lint (golangci-lint), build+vet, test, <strong>govulncheck</strong>,
-        and an optional integration pass. Inputs (<code>go-version-file</code>, <code>golangci-lint-version</code>,
-        <code>run-integration</code>, <code>integration-packages</code>, …) carry sane defaults. Repo-specific jobs
-        (e.g. <code>core</code>'s sqlc/mocks codegen-drift check) stay in the caller workflow alongside the <code>uses:</code> job.</li>
-      <li><strong><code>codeql</code></strong> — CodeQL analysis of Go source <strong>and</strong> the repo's own
-        Actions workflows. The reusable workflow declares the permissions it needs; GitHub intersects them with what the caller grants.</li>
-      <li><strong>Versioning:</strong> published behind a moving major tag <strong><code>@v1</code></strong> (immutable
-        <code>v1.0.0</code> anchor underneath). Callers pin <code>…/go-ci.yml@v1</code>; patch/minor fixes move the
-        <code>v1</code> tag with no caller change. A <code>.github/zizmor.yml</code> <code>ref-pin</code> policy allows
-        first-party (<code>fair-n-square-co/*</code>) tag refs while keeping all third-party actions pinned to a full commit SHA.</li>
-      <li><strong>First adopter:</strong> <code>core</code>. Roll out to <code>auth-api</code> and other Go services as they come online.</li>
-    </ul>
+    <h3>Service CI is per-repo; CD is centralized in <code>.github</code></h3>
+    <p>CI stays with each service. Every repo owns its full pipeline in its own <code>.github/workflows/</code> — lint (golangci-lint), build+vet, test, govulncheck, and CodeQL, with all actions pinned to a commit SHA. We deliberately do <strong>not</strong> factor CI into org-wide reusable workflows: keeping it per-repo lets each service evolve its pipeline independently, and the duplication is small (one workflow file).</p>
+    <p>CD is the part worth centralizing. The org repo <strong><code>fair-n-square-co/.github</code></strong> is reserved for reusable <strong>deployment</strong> workflows (build image → push to ECR → deploy to ECS Fargate) that services call via <code>workflow_call</code>. These land with the deploy automation in FNS-114, once OIDC + ECR + the ECS cluster exist — there's nothing to deploy on the resource-free skeleton yet.</p>
     <h3>Build order</h3>
     <p>1. Bootstrap state → 2. OIDC + IAM → 3. Networking → 4. Data (RDS + ECR) → 5. Edge + services
       (ACM/Route53, ALB, cluster, ×4 ecs-service) → 6. Messaging (EventBridge/SQS/SNS + Worker) → 7. CI.</p>

--- a/docs/aws-architecture.html
+++ b/docs/aws-architecture.html
@@ -226,6 +226,24 @@
       <li><strong>Merge → apply:</strong> download the <em>same</em> plan artifact and <code>tofu apply tfplan</code>. Gate prod behind a GitHub Environment with required reviewers; <code>concurrency</code> groups per env.</li>
       <li>Skip Atlantis/Spacelift/TFC for now (overkill for two people).</li>
     </ul>
+    <h3>Shared service CI — reusable workflows in <code>.github</code></h3>
+    <p>The infra <code>plan</code>/<code>apply</code> workflows above are repo-local. <strong>Service</strong> CI
+      (Go build/test/lint, CodeQL) is factored out once into the org repo <strong><code>fair-n-square-co/.github</code></strong>
+      and consumed by each service via <code>workflow_call</code>, so a new Go service gets full CI in
+      ~10 lines instead of copy-pasting a pipeline.</p>
+    <ul>
+      <li><strong><code>go-ci.yml</code></strong> — lint (golangci-lint), build+vet, test, <strong>govulncheck</strong>,
+        and an optional integration pass. Inputs (<code>go-version-file</code>, <code>golangci-lint-version</code>,
+        <code>run-integration</code>, <code>integration-packages</code>, …) carry sane defaults. Repo-specific jobs
+        (e.g. <code>core</code>'s sqlc/mocks codegen-drift check) stay in the caller workflow alongside the <code>uses:</code> job.</li>
+      <li><strong><code>codeql.yml</code></strong> — CodeQL analysis of Go source <strong>and</strong> the repo's own
+        Actions workflows. The reusable workflow declares the permissions it needs; GitHub intersects them with what the caller grants.</li>
+      <li><strong>Versioning:</strong> published behind a moving major tag <strong><code>@v1</code></strong> (immutable
+        <code>v1.0.0</code> anchor underneath). Callers pin <code>…/go-ci.yml@v1</code>; patch/minor fixes move the
+        <code>v1</code> tag with no caller change. A <code>.github/zizmor.yml</code> <code>ref-pin</code> policy allows
+        first-party (<code>fair-n-square-co/*</code>) tag refs while keeping all third-party actions pinned to a full commit SHA.</li>
+      <li><strong>First adopter:</strong> <code>core</code>. Roll out to <code>auth-api</code> and other Go services as they come online.</li>
+    </ul>
     <h3>Build order</h3>
     <p>1. Bootstrap state → 2. OIDC + IAM → 3. Networking → 4. Data (RDS + ECR) → 5. Edge + services
       (ACM/Route53, ALB, cluster, ×4 ecs-service) → 6. Messaging (EventBridge/SQS/SNS + Worker) → 7. CI.</p>

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -205,6 +205,23 @@ Anything Tofu reads/sets becomes plaintext in state. In order of preference:
   **GitHub Environment with required reviewers**. Use `concurrency` groups per env.
 - Skip Atlantis/Spacelift/TFC for now (overkill for two people).
 
+### Shared service CI — reusable workflows in `.github`
+The infra `plan`/`apply` workflows above are repo-local. **Service** CI (Go build/test/lint, CodeQL)
+is factored out once into the org repo **`fair-n-square-co/.github`** and consumed by each service via
+`workflow_call`, so a new Go service gets full CI in ~10 lines instead of copy-pasting a pipeline.
+
+- **`go-ci.yml`** — lint (golangci-lint), build+vet, test, **govulncheck**, and an optional integration
+  pass. Inputs (`go-version-file`, `golangci-lint-version`, `run-integration`, `integration-packages`,
+  …) carry sane defaults. Repo-specific jobs (e.g. `core`'s sqlc/mocks codegen-drift check) stay in the
+  caller workflow alongside the `uses:` job.
+- **`codeql.yml`** — CodeQL analysis of Go source **and** the repo's own Actions workflows. The reusable
+  workflow declares the permissions it needs; GitHub intersects them with what the caller grants.
+- **Versioning:** published behind a moving major tag **`@v1`** (immutable `v1.0.0` anchor underneath).
+  Callers pin `…/go-ci.yml@v1`; patch/minor fixes move the `v1` tag with no caller change. A
+  `.github/zizmor.yml` `ref-pin` policy allows first-party (`fair-n-square-co/*`) tag refs while keeping
+  all third-party actions pinned to a full commit SHA.
+- **First adopter:** `core`. Roll out to `auth-api` and other Go services as they come online.
+
 ### Build order
 1. **Bootstrap state** (S3 + KMS) → migrate env roots to S3 backend.
 2. **OIDC + IAM** (GitHub provider, CI role, ECS exec/task roles).

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -207,20 +207,12 @@ Anything Tofu reads/sets becomes plaintext in state. In order of preference:
 
 ### Shared service CI — reusable workflows in `.github`
 
-The infra `plan`/`apply` workflows above are repo-local. **Service** CI (Go build/test/lint, CodeQL)
-is factored out once into the org repo **`fair-n-square-co/.github`** and consumed by each service via
-`workflow_call`, so a new Go service gets full CI in ~10 lines instead of copy-pasting a pipeline.
+The infra `plan`/`apply` workflows above are repo-local.
+**Service** CI (Go build/test/lint, CodeQL) is factored out once into the org repo **`fair-n-square-co/.github`** and consumed by each service via `workflow_call`, so a new Go service gets full CI in ~10 lines instead of copy-pasting a pipeline.
 
-- **`go-ci`** — lint (golangci-lint), build+vet, test, **govulncheck**, and an optional integration
-  pass. Inputs (`go-version-file`, `golangci-lint-version`, `run-integration`, `integration-packages`,
-  …) carry sane defaults. Repo-specific jobs (e.g. `core`'s sqlc/mocks codegen-drift check) stay in the
-  caller workflow alongside the `uses:` job.
-- **`codeql`** — CodeQL analysis of Go source **and** the repo's own Actions workflows. The reusable
-  workflow declares the permissions it needs; GitHub intersects them with what the caller grants.
-- **Versioning:** published behind a moving major tag **`@v1`** (immutable `v1.0.0` anchor underneath).
-  Callers pin `…/go-ci.yml@v1`; patch/minor fixes move the `v1` tag with no caller change. A
-  `.github/zizmor.yml` `ref-pin` policy allows first-party (`fair-n-square-co/*`) tag refs while keeping
-  all third-party actions pinned to a full commit SHA.
+- **`go-ci`** — lint (golangci-lint), build+vet, test, **govulncheck**, and an optional integration pass. Inputs (`go-version-file`, `golangci-lint-version`, `run-integration`, `integration-packages`, …) carry sane defaults. Repo-specific jobs (e.g. `core`'s sqlc/mocks codegen-drift check) stay in the caller workflow alongside the `uses:` job.
+- **`codeql`** — CodeQL analysis of Go source **and** the repo's own Actions workflows. The reusable workflow declares the permissions it needs; GitHub intersects them with what the caller grants.
+- **Versioning:** published behind a moving major tag **`@v1`** (immutable `v1.0.0` anchor underneath). Callers pin `…/go-ci.yml@v1`; patch/minor fixes move the `v1` tag with no caller change. A `.github/zizmor.yml` `ref-pin` policy allows first-party (`fair-n-square-co/*`) tag refs while keeping all third-party actions pinned to a full commit SHA.
 - **First adopter:** `core`. Roll out to `auth-api` and other Go services as they come online.
 
 ### Build order

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -1,6 +1,6 @@
 # Fair N Square — AWS Architecture, Distributed System & IaC
 
-> **Status:** Draft for review · **Last updated:** 2026-06-20
+> **Status:** Draft for review · **Last updated:** 2026-06-28
 >
 > This document explores deploying Fair N Square on **AWS** (as a deliberate learning exercise),
 > evolving it into a genuinely **distributed system**, and provisioning it with **OpenTofu**.
@@ -206,15 +206,16 @@ Anything Tofu reads/sets becomes plaintext in state. In order of preference:
 - Skip Atlantis/Spacelift/TFC for now (overkill for two people).
 
 ### Shared service CI — reusable workflows in `.github`
+
 The infra `plan`/`apply` workflows above are repo-local. **Service** CI (Go build/test/lint, CodeQL)
 is factored out once into the org repo **`fair-n-square-co/.github`** and consumed by each service via
 `workflow_call`, so a new Go service gets full CI in ~10 lines instead of copy-pasting a pipeline.
 
-- **`go-ci.yml`** — lint (golangci-lint), build+vet, test, **govulncheck**, and an optional integration
+- **`go-ci`** — lint (golangci-lint), build+vet, test, **govulncheck**, and an optional integration
   pass. Inputs (`go-version-file`, `golangci-lint-version`, `run-integration`, `integration-packages`,
   …) carry sane defaults. Repo-specific jobs (e.g. `core`'s sqlc/mocks codegen-drift check) stay in the
   caller workflow alongside the `uses:` job.
-- **`codeql.yml`** — CodeQL analysis of Go source **and** the repo's own Actions workflows. The reusable
+- **`codeql`** — CodeQL analysis of Go source **and** the repo's own Actions workflows. The reusable
   workflow declares the permissions it needs; GitHub intersects them with what the caller grants.
 - **Versioning:** published behind a moving major tag **`@v1`** (immutable `v1.0.0` anchor underneath).
   Callers pin `…/go-ci.yml@v1`; patch/minor fixes move the `v1` tag with no caller change. A

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -1,6 +1,6 @@
 # Fair N Square — AWS Architecture, Distributed System & IaC
 
-> **Status:** Draft for review · **Last updated:** 2026-06-28
+> **Status:** Draft for review · **Last updated:** 2026-06-29
 >
 > This document explores deploying Fair N Square on **AWS** (as a deliberate learning exercise),
 > evolving it into a genuinely **distributed system**, and provisioning it with **OpenTofu**.
@@ -205,14 +205,11 @@ Anything Tofu reads/sets becomes plaintext in state. In order of preference:
   **GitHub Environment with required reviewers**. Use `concurrency` groups per env.
 - Skip Atlantis/Spacelift/TFC for now (overkill for two people).
 
-### Shared service CI — reusable workflows in `.github`
+### Service CI is per-repo; CD is centralized in `.github`
 
-The infra `plan`/`apply` workflows above are repo-local.
-**Service** CI (Go build/test/lint, CodeQL) is factored out once into the org repo **`fair-n-square-co/.github`** and consumed by each service via `workflow_call`, so a new Go service gets full CI in ~10 lines instead of copy-pasting a pipeline.
+CI stays with each service. Every repo owns its full pipeline in its own `.github/workflows/` — lint (golangci-lint), build+vet, test, govulncheck, and CodeQL, with all actions pinned to a commit SHA. We deliberately do **not** factor CI into org-wide reusable workflows: keeping it per-repo lets each service evolve its pipeline independently, and the duplication is small (one workflow file).
 
-- **`go-ci`** — lint (golangci-lint), build+vet, test, **govulncheck**, and an optional integration pass. Inputs (`go-version-file`, `golangci-lint-version`, `run-integration`, `integration-packages`, …) carry sane defaults. Repo-specific jobs (e.g. `core`'s sqlc/mocks codegen-drift check) stay in the caller workflow alongside the `uses:` job.
-- **`codeql`** — CodeQL analysis of Go source **and** the repo's own Actions workflows. The reusable workflow declares the permissions it needs; GitHub intersects them with what the caller grants.
-- **Versioning:** published behind a moving major tag **`@v1`** (immutable `v1.0.0` anchor underneath). Callers pin `…/go-ci.yml@v1`; patch/minor fixes move the `v1` tag with no caller change. A `.github/zizmor.yml` `ref-pin` policy allows first-party (`fair-n-square-co/*`) tag refs while keeping all third-party actions pinned to a full commit SHA.
+CD is the part worth centralizing. The org repo **`fair-n-square-co/.github`** is reserved for reusable **deployment** workflows (build image → push to ECR → deploy to ECS Fargate) that services call via `workflow_call`. These land with the deploy automation in FNS-114, once OIDC + ECR + the ECS cluster exist — there's nothing to deploy on the resource-free skeleton yet.
 - **First adopter:** `core`. Roll out to `auth-api` and other Go services as they come online.
 
 ### Build order

--- a/docs/repos.html
+++ b/docs/repos.html
@@ -52,7 +52,7 @@
       what's needed, and what to clean up. Goal: from 13 repos down to ~8 active (+2 archived).</p>
     <div class="meta-row">
       <span class="chip">Status: Draft for review</span>
-      <span class="chip">Updated: 2026-06-28</span>
+      <span class="chip">Updated: 2026-06-29</span>
       <span class="chip"><a href="./index.html">← Docs index</a></span>
       <span class="chip"><a href="./delivery-plan.html">Delivery plan</a></span>
       <span class="chip"><a href="./aws-architecture.html">AWS architecture</a></span>
@@ -75,7 +75,7 @@
       <tr><td><code>app</code></td><td>Old Flutter mobile bootstrap</td><td>Dart</td><td>2024-05-23</td><td><span class="v v-arch">Archive</span> (mobile is post-MVP)</td></tr>
       <tr><td><code>codecov-login</code></td><td>Throwaway Codecov OAuth helper, single <code>main.go</code></td><td>Go</td><td>2024-04-25</td><td><span class="v v-del">Delete</span></td></tr>
       <tr><td><code>demo-repository</code></td><td>GitHub default demo template, never used</td><td>HTML</td><td>2024-03-18</td><td><span class="v v-del">Delete</span></td></tr>
-      <tr><td><code>.github</code></td><td>Org profile <strong>+ reusable CI/CD workflows</strong> (<code>go-ci</code>, <code>codeql</code>) consumed by service repos via <code>workflow_call</code>, versioned <code>@v1</code> (FNS-85)</td><td>YAML</td><td>2026-06-28</td><td><span class="v v-keep">Keep</span> — shared CI home; flesh out org README</td></tr>
+      <tr><td><code>.github</code></td><td>Org profile; <strong>reserved for reusable CD (deploy) workflows</strong> (FNS-114). CI is owned per-repo, not centralized here.</td><td>—</td><td>2026-06-29</td><td><span class="v v-keep">Keep</span> — future CD home; flesh out org README</td></tr>
     </table>
   </section>
 
@@ -94,7 +94,7 @@
     </table>
     <div class="callout"><strong>Both repo gaps now closed; follow-up work remains:</strong>
       <br>1. <del><code>core</code></del> ✅ Being created under FNS-84 (FNS-133, FNS-134). <code>ledger</code> folding in; archived after.
-      <br>2. <del><code>infra</code></del> ✅ Created under FNS-85: OpenTofu skeleton (ECS Fargate per <a href="./aws-architecture.html">AWS architecture</a> §2) + plan/apply CI. Remaining: <strong>drop</strong> the K8s manifests from <code>e2e</code> — not relocated, since k8s is no longer a deploy target under the Fargate decision; <code>e2e</code> runs on docker-compose, and <code>infra</code> can host a full-stack compose for local bring-up. ✅ Per-repo CI consolidated into reusable workflows in <strong><code>.github</code></strong> (<code>go-ci</code>, <code>codeql</code>, referenced <code>@v1</code>); <code>core</code> is the first adopter.</div>
+      <br>2. <del><code>infra</code></del> ✅ Created under FNS-85: OpenTofu skeleton (ECS Fargate per <a href="./aws-architecture.html">AWS architecture</a> §2) + plan/apply CI. Remaining: <strong>drop</strong> the K8s manifests from <code>e2e</code> — not relocated, since k8s is no longer a deploy target under the Fargate decision; <code>e2e</code> runs on docker-compose, and <code>infra</code> can host a full-stack compose for local bring-up. Service <strong>CI is owned per-repo</strong> (<code>core</code> inlines its own lint/build/test/govulncheck/CodeQL, all SHA-pinned); the <strong><code>.github</code></strong> org repo is reserved for reusable <strong>CD</strong> (deploy) workflows (FNS-114).</div>
   </section>
 
   <section>
@@ -120,7 +120,7 @@
       <tr><td><code>infra</code> <span class="v v-new">new</span></td><td>OpenTofu/AWS (ECS Fargate) + reusable OpenTofu modules + local-stack docker-compose</td></tr>
       <tr><td><code>e2e</code></td><td>Cross-service E2E tests</td></tr>
       <tr><td><code>docs</code></td><td>ADRs, roadmap, product spec, diagrams</td></tr>
-      <tr><td><code>.github</code></td><td>Org profile + shared community-health files + <strong>reusable CI/CD workflows</strong> (<code>go-ci</code>, <code>codeql</code>, <code>@v1</code>)</td></tr>
+      <tr><td><code>.github</code></td><td>Org profile + shared community-health files + <strong>reusable CD (deploy) workflows</strong> (FNS-114; CI is per-repo)</td></tr>
     </table>
     <p><strong>Archived (reference only):</strong> <code>transactions</code>, <code>app</code>, <code>ledger</code> (after its code folds into <code>core</code>).
        <strong>Deleted:</strong> <code>web-app</code>, <code>jwt-service</code>, <code>codecov-login</code>, <code>demo-repository</code>.</p>

--- a/docs/repos.html
+++ b/docs/repos.html
@@ -117,14 +117,14 @@
       <tr><td><code>auth-api</code> <span class="v v-arch">rename?</span></td><td>Go Auth Service: profiles, JWKs, M2M tokens, ReBAC</td></tr>
       <tr><td><code>core</code> <span class="v v-new">new</span></td><td>Go modular-monolith Core Service: groups, friends, expenses, settlement, ledger</td></tr>
       <tr><td><code>apis</code></td><td>Buf/connectRPC contracts + generated Go/TS clients</td></tr>
-      <tr><td><code>infra</code> <span class="v v-new">new</span></td><td>OpenTofu/AWS (ECS Fargate) + reusable CI/CD workflows + local-stack docker-compose</td></tr>
+      <tr><td><code>infra</code> <span class="v v-new">new</span></td><td>OpenTofu/AWS (ECS Fargate) + reusable OpenTofu modules + local-stack docker-compose</td></tr>
       <tr><td><code>e2e</code></td><td>Cross-service E2E tests</td></tr>
       <tr><td><code>docs</code></td><td>ADRs, roadmap, product spec, diagrams</td></tr>
       <tr><td><code>.github</code></td><td>Org profile + shared community-health files + <strong>reusable CI/CD workflows</strong> (<code>go-ci</code>, <code>codeql</code>, <code>@v1</code>)</td></tr>
     </table>
-    <p><strong>Archived (reference only):</strong> <code>transactions</code>, <code>app</code>.
-       <strong>Deleted:</strong> <code>web-app</code>, <code>ledger</code> (after merge), <code>jwt-service</code>, <code>codecov-login</code>, <code>demo-repository</code>.</p>
-    <p>→ From <strong>13 repos to ~8 active</strong> (+2 archived).</p>
+    <p><strong>Archived (reference only):</strong> <code>transactions</code>, <code>app</code>, <code>ledger</code> (after its code folds into <code>core</code>).
+       <strong>Deleted:</strong> <code>web-app</code>, <code>jwt-service</code>, <code>codecov-login</code>, <code>demo-repository</code>.</p>
+    <p>→ From <strong>13 repos to ~8 active</strong> (+3 archived).</p>
   </section>
 
   <section>

--- a/docs/repos.html
+++ b/docs/repos.html
@@ -52,7 +52,7 @@
       what's needed, and what to clean up. Goal: from 13 repos down to ~8 active (+2 archived).</p>
     <div class="meta-row">
       <span class="chip">Status: Draft for review</span>
-      <span class="chip">Updated: 2026-06-20</span>
+      <span class="chip">Updated: 2026-06-28</span>
       <span class="chip"><a href="./index.html">← Docs index</a></span>
       <span class="chip"><a href="./delivery-plan.html">Delivery plan</a></span>
       <span class="chip"><a href="./aws-architecture.html">AWS architecture</a></span>
@@ -64,10 +64,10 @@
     <table>
       <tr><th>Repo</th><th>Purpose (inferred)</th><th>Lang</th><th>Last push</th><th>Verdict</th></tr>
       <tr><td><code>webapp</code></td><td>SvelteKit UI + BFF + Better Auth login (drizzle, storybook, playwright, husky)</td><td>TS</td><td>2025-12-15</td><td><span class="v v-keep">Keep</span> canonical frontend; re-scaffold on React + WorkOS (ADR-5/4)</td></tr>
-      <tr><td><code>apis</code></td><td>Proto/contracts: buf + connectRPC, generated Go+TS</td><td>TS</td><td>2025-12-13</td><td><span class="v v-keep">Keep</span> + rename → <code>proto</code></td></tr>
+      <tr><td><code>apis</code></td><td>Proto/contracts: buf + connectRPC, generated Go+TS</td><td>TS</td><td>2025-12-13</td><td><span class="v v-keep">Keep</span> (retain the <code>apis</code> name — no rename)</td></tr>
       <tr><td><code>docs</code></td><td>ADRs, roadmap, product spec, diagrams (this repo)</td><td>—</td><td>2026-06-19</td><td><span class="v v-keep">Keep</span></td></tr>
-      <tr><td><code>ledger</code></td><td>Ledger/transactions service — sqlc + goose</td><td>Go</td><td>2026-03-18</td><td><span class="v v-arch">Fold</span> into <code>core</code></td></tr>
-      <tr><td><code>e2e</code></td><td>Cross-service E2E tests + K8s manifests + docker-compose</td><td>Go</td><td>2026-03-18</td><td><span class="v v-keep">Keep</span> (move infra bits out)</td></tr>
+      <tr><td><code>ledger</code></td><td>Ledger/transactions service — sqlc + goose</td><td>Go</td><td>2026-03-18</td><td><span class="v v-arch">Fold</span> into <code>core</code> (FNS-134); archive after</td></tr>
+      <tr><td><code>e2e</code></td><td>Cross-service E2E tests + docker-compose</td><td>Go</td><td>2026-03-18</td><td><span class="v v-keep">Keep</span> (drop unused K8s manifests; stays docker-compose-based)</td></tr>
       <tr><td><code>auth-api</code></td><td>Intended Auth Service (Go) — README is verbatim "Go API Template"; an unmodified bootstrap</td><td>Go</td><td>2025-09-30</td><td><span class="v v-keep">Keep</span> but reset — barely started</td></tr>
       <tr><td><code>jwt-service</code></td><td>Throwaway: create a JWT for testing via Firebase, single <code>jwt.go</code></td><td>Go</td><td>2026-06-17</td><td><span class="v v-del">Merge→Delete</span></td></tr>
       <tr><td><code>transactions</code></td><td>Legacy v0 backend (GORM + Atlas + Fly). Makefile style reference</td><td>Go</td><td>2024-08</td><td><span class="v v-arch">Archive</span></td></tr>
@@ -75,7 +75,7 @@
       <tr><td><code>app</code></td><td>Old Flutter mobile bootstrap</td><td>Dart</td><td>2024-05-23</td><td><span class="v v-arch">Archive</span> (mobile is post-MVP)</td></tr>
       <tr><td><code>codecov-login</code></td><td>Throwaway Codecov OAuth helper, single <code>main.go</code></td><td>Go</td><td>2024-04-25</td><td><span class="v v-del">Delete</span></td></tr>
       <tr><td><code>demo-repository</code></td><td>GitHub default demo template, never used</td><td>HTML</td><td>2024-03-18</td><td><span class="v v-del">Delete</span></td></tr>
-      <tr><td><code>.github</code></td><td>Org profile</td><td>—</td><td>2024-03-18</td><td><span class="v v-keep">Keep</span> — flesh out</td></tr>
+      <tr><td><code>.github</code></td><td>Org profile <strong>+ reusable CI/CD workflows</strong> (<code>go-ci</code>, <code>codeql</code>) consumed by service repos via <code>workflow_call</code>, versioned <code>@v1</code> (FNS-85)</td><td>YAML</td><td>2026-06-28</td><td><span class="v v-keep">Keep</span> — shared CI home; flesh out org README</td></tr>
     </table>
   </section>
 
@@ -85,17 +85,16 @@
       <tr><th>Component (from ADRs)</th><th>Repo home</th><th>Status</th></tr>
       <tr><td>React UI + BFF (+ WorkOS AuthKit login)</td><td><code>webapp</code></td><td>⚠️ exists as SvelteKit; re-scaffold on React (ADR-5)</td></tr>
       <tr><td>Auth Service (Go) — profiles, JWKs, M2M, ReBAC</td><td><code>auth-api</code></td><td>⚠️ exists but an empty template; needs real implementation</td></tr>
-      <tr><td><strong>Core Service</strong> (Go modular monolith) — groups, friends, expenses, settlement, ledger</td><td><strong>— gap —</strong></td><td>❌ No <code>core</code> repo. <code>ledger</code> covers only the ledger slice.</td></tr>
-      <tr><td>Proto / contracts</td><td><code>apis</code> → <code>proto</code></td><td>✅</td></tr>
+      <tr><td><strong>Core Service</strong> (Go modular monolith) — groups, friends, expenses, settlement, ledger</td><td><code>core</code></td><td>⚠️ Scaffolding in progress (FNS-133, FNS-134).</td></tr>
+      <tr><td>Proto / contracts</td><td><code>apis</code></td><td>✅ (matches the "Configure Proto Repository" subtask)</td></tr>
       <tr><td>Two Postgres DBs (Auth, Core)</td><td>inside <code>auth-api</code> + <code>core</code></td><td>✅ sqlc/goose migrations</td></tr>
       <tr><td>Docs</td><td><code>docs</code></td><td>✅</td></tr>
-      <tr><td><strong>Infra / OpenTofu</strong></td><td><strong>— gap —</strong></td><td>❌ No infra repo. K8s manifests currently live in <code>e2e</code>.</td></tr>
+      <tr><td><strong>Infra / OpenTofu</strong></td><td><code>infra</code></td><td>⚠️ Repo created with the OpenTofu skeleton + CI (FNS-85); no AWS resources yet (FNS-112/113/114). Unused K8s manifests to be dropped from <code>e2e</code> (Fargate, not k8s).</td></tr>
       <tr><td>E2E</td><td><code>e2e</code></td><td>✅</td></tr>
     </table>
-    <div class="callout"><strong>Two gaps to create:</strong>
-      <br>1. <code>core</code> — the Core Service; fold <code>ledger</code> into it as a module.
-      <em>ADR-2 says "treat core service as a monolith… don't break into smaller services" — a separate <code>ledger</code> repo contradicts that.</em>
-      <br>2. <code>infra</code> — OpenTofu/AWS + k8s + reusable CI/CD (see <a href="./aws-architecture.html">AWS architecture</a>); move K8s manifests out of <code>e2e</code>.</div>
+    <div class="callout"><strong>Both repo gaps now closed; follow-up work remains:</strong>
+      <br>1. <del><code>core</code></del> ✅ Being created under FNS-84 (FNS-133, FNS-134). <code>ledger</code> folding in; archived after.
+      <br>2. <del><code>infra</code></del> ✅ Created under FNS-85: OpenTofu skeleton (ECS Fargate per <a href="./aws-architecture.html">AWS architecture</a> §2) + plan/apply CI. Remaining: <strong>drop</strong> the K8s manifests from <code>e2e</code> — not relocated, since k8s is no longer a deploy target under the Fargate decision; <code>e2e</code> runs on docker-compose, and <code>infra</code> can host a full-stack compose for local bring-up. ✅ Per-repo CI consolidated into reusable workflows in <strong><code>.github</code></strong> (<code>go-ci</code>, <code>codeql</code>, referenced <code>@v1</code>); <code>core</code> is the first adopter.</div>
   </section>
 
   <section>
@@ -105,8 +104,7 @@
       <li><strong>Salvage then remove <code>jwt-service</code>:</strong> move <code>jwt.go</code> into <code>e2e</code> test helpers or <code>webapp</code> dev tooling, commit, then archive/delete.</li>
       <li><strong>Back up private/unique repos</strong> before any delete: <code>git clone --mirror</code> <code>jwt-service</code> + <code>codecov-login</code> into <code>.tmp/</code>.</li>
       <li><strong>Delete dead repos</strong> (zero reusable value): <code>codecov-login</code>, <code>demo-repository</code>. (Archiving is also fine and safer.)</li>
-      <li><strong>Rename</strong> <code>apis</code> → <code>proto</code> (GitHub auto-redirects; update buf module paths + imports).</li>
-      <li><strong>Create</strong> <code>core</code> and <code>infra</code>; fold <code>ledger</code> into <code>core</code>, then archive <code>ledger</code>.</li>
+      <li><strong>Create</strong> <code>core</code> and <code>infra</code>; fold <code>ledger</code> into <code>core</code>, then archive <code>ledger</code>. <em>(The <code>apis</code> contracts repo keeps its name — no rename to <code>proto</code>.)</em></li>
     </ol>
     <div class="callout"><strong>GitHub repo deletion is irreversible</strong> — archive when in doubt. Verify archived/private flags before acting.</div>
   </section>
@@ -118,14 +116,15 @@
       <tr><td><code>webapp</code></td><td>React UI + BFF; hosts WorkOS AuthKit login &amp; sessions</td></tr>
       <tr><td><code>auth-api</code> <span class="v v-arch">rename?</span></td><td>Go Auth Service: profiles, JWKs, M2M tokens, ReBAC</td></tr>
       <tr><td><code>core</code> <span class="v v-new">new</span></td><td>Go modular-monolith Core Service: groups, friends, expenses, settlement, ledger</td></tr>
-      <tr><td><code>proto</code> <span class="v v-new">renamed</span></td><td>Buf/connectRPC contracts + generated Go/TS clients</td></tr>
-      <tr><td><code>infra</code> <span class="v v-new">new</span></td><td>OpenTofu/AWS + k8s + reusable CI/CD workflows</td></tr>
+      <tr><td><code>apis</code></td><td>Buf/connectRPC contracts + generated Go/TS clients</td></tr>
+      <tr><td><code>infra</code> <span class="v v-new">new</span></td><td>OpenTofu/AWS (ECS Fargate) + reusable CI/CD workflows + local-stack docker-compose</td></tr>
       <tr><td><code>e2e</code></td><td>Cross-service E2E tests</td></tr>
       <tr><td><code>docs</code></td><td>ADRs, roadmap, product spec, diagrams</td></tr>
-      <tr><td><code>.github</code></td><td>Org profile + shared community-health files</td></tr>
+      <tr><td><code>.github</code></td><td>Org profile + shared community-health files + <strong>reusable CI/CD workflows</strong> (<code>go-ci</code>, <code>codeql</code>, <code>@v1</code>)</td></tr>
     </table>
     <p><strong>Archived (reference only):</strong> <code>transactions</code>, <code>app</code>.
        <strong>Deleted:</strong> <code>web-app</code>, <code>ledger</code> (after merge), <code>jwt-service</code>, <code>codecov-login</code>, <code>demo-repository</code>.</p>
+    <p>→ From <strong>13 repos to ~8 active</strong> (+2 archived).</p>
   </section>
 
   <section>
@@ -138,10 +137,10 @@
       <li><strong>Go monorepo</strong> to ship the MVP faster — eliminates cross-repo proto-versioning pain (brutal for 1–2 people) while still building independent service containers.</li>
     </ul>
     <div class="callout"><strong>Concrete recommendation:</strong> monorepo for code
-      (<code>core</code>, <code>auth</code>, <code>webapp</code>, <code>proto</code>, <code>infra</code>,
+      (<code>core</code>, <code>auth</code>, <code>webapp</code>, <code>apis</code>, <code>infra</code>,
       <code>e2e</code> as top-level dirs) + keep <code>docs</code> separate. ~90% of the architectural
       learning without the cross-repo coordination tax that dominates solo work. If you specifically
-      want the cross-repo contract-publishing lesson, keep <code>proto</code> split out and monorepo the rest.</div>
+      want the cross-repo contract-publishing lesson, keep <code>apis</code> split out and monorepo the rest.</div>
   </section>
 
   <footer>

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-> **Status:** Draft for review · **Last updated:** 2026-06-22
+> **Status:** Draft for review · **Last updated:** 2026-06-28
 >
 > An audit of the `fair-n-square-co` GitHub org: what each repo is for, what's needed, and what to
 > clean up. Companion: [`./delivery-plan.html`](./delivery-plan.html), [`./aws-architecture.html`](./aws-architecture.html).
@@ -23,7 +23,7 @@
 | **app** | Old Flutter mobile bootstrap | Dart | 2024-05-23 | Stale; mobile is post-MVP | **ARCHIVE** |
 | **codecov-login** | Throwaway Codecov OAuth helper, single `main.go` | Go | 2024-04-25 | Dead | **DELETE** |
 | **demo-repository** | GitHub default demo template, never used | HTML | 2024-03-18 | Dead | **DELETE** |
-| **.github** | Org profile | — | 2024-03-18 | Minimal | **KEEP** — flesh out org README |
+| **.github** | Org profile **+ reusable CI/CD workflows** (`go-ci`, `codeql`) consumed by service repos via `workflow_call`, versioned `@v1` ([FNS-85](https://loyalt.atlassian.net/browse/FNS-85)) | YAML | 2026-06-28 | Active | **KEEP** — shared CI home; flesh out org README |
 
 ---
 
@@ -43,7 +43,7 @@
 **Both repo gaps now closed; follow-up work remains:**
 
 1. ~~**`core`**~~ — ✅ Being created under [FNS-84](https://loyalt.atlassian.net/browse/FNS-84) (subtasks [FNS-133](https://loyalt.atlassian.net/browse/FNS-133), [FNS-134](https://loyalt.atlassian.net/browse/FNS-134)). `ledger` folding in; archived after.
-2. ~~**`infra`**~~ — ✅ Created under [FNS-85](https://loyalt.atlassian.net/browse/FNS-85): OpenTofu skeleton (ECS Fargate per [`./aws-architecture.html`](./aws-architecture.html) §2) + plan/apply CI. Remaining: **drop** the K8s manifests from `e2e` — not relocated, since k8s is no longer a deploy target under the Fargate decision; `e2e` runs on docker-compose, and `infra` can host a full-stack compose for local bring-up. Also consolidate per-repo CI into reusable workflows in `.github`.
+2. ~~**`infra`**~~ — ✅ Created under [FNS-85](https://loyalt.atlassian.net/browse/FNS-85): OpenTofu skeleton (ECS Fargate per [`./aws-architecture.html`](./aws-architecture.html) §2) + plan/apply CI. Remaining: **drop** the K8s manifests from `e2e` — not relocated, since k8s is no longer a deploy target under the Fargate decision; `e2e` runs on docker-compose, and `infra` can host a full-stack compose for local bring-up. ✅ Per-repo CI consolidated into reusable workflows in **`.github`** (`go-ci`, `codeql`, referenced `@v1`); `core` is the first adopter.
 
 ---
 
@@ -72,7 +72,7 @@
 | `infra` | OpenTofu/AWS (ECS Fargate) + reusable CI/CD workflows + local-stack docker-compose |
 | `e2e` | Cross-service E2E tests |
 | `docs` | ADRs, roadmap, product spec, diagrams |
-| `.github` | Org profile + shared community-health files |
+| `.github` | Org profile + shared community-health files + **reusable CI/CD workflows** (`go-ci`, `codeql`, `@v1`) |
 
 **Archived (reference only):** `transactions`, `app`. **Deleted:** `web-app`, `ledger` (after merge),
 `jwt-service`, `codecov-login`, `demo-repository`.

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -69,15 +69,15 @@
 | `auth-api` *(consider rename `auth`)* | Go Auth Service: profiles, JWKs, M2M tokens, ReBAC |
 | `core` | Go modular-monolith Core Service: groups, friends, expenses, settlement, ledger |
 | `apis` | Buf/connectRPC contracts + generated Go/TS clients |
-| `infra` | OpenTofu/AWS (ECS Fargate) + reusable CI/CD workflows + local-stack docker-compose |
+| `infra` | OpenTofu/AWS (ECS Fargate) + reusable OpenTofu modules + local-stack docker-compose |
 | `e2e` | Cross-service E2E tests |
 | `docs` | ADRs, roadmap, product spec, diagrams |
 | `.github` | Org profile + shared community-health files + **reusable CI/CD workflows** (`go-ci`, `codeql`, `@v1`) |
 
-**Archived (reference only):** `transactions`, `app`. **Deleted:** `web-app`, `ledger` (after merge),
-`jwt-service`, `codecov-login`, `demo-repository`.
+**Archived (reference only):** `transactions`, `app`, `ledger` (after its code folds into `core`).
+**Deleted:** `web-app`, `jwt-service`, `codecov-login`, `demo-repository`.
 
-→ From **13 repos to ~8 active** (+2 archived).
+→ From **13 repos to ~8 active** (+3 archived).
 
 ---
 

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -15,7 +15,7 @@
 | **apis** | Proto/contracts: `buf` + connectRPC, `proto/fairnsquare`, generated Go+TS | TS | 2025-12-13 | Active | **KEEP** (retain the `apis` name — no rename) |
 | **docs** | ADRs, roadmap, product spec, diagrams (this repo) | — | 2026-06-19 | Active | **KEEP** |
 | **ledger** | Ledger/transactions service — sqlc + goose | Go/PLpgSQL | 2026-03-18 | Active-ish | **FOLDING into `core`** ([FNS-134](https://loyalt.atlassian.net/browse/FNS-134)) — archive after done |
-| **e2e** | Cross-service E2E tests + K8s manifests + docker-compose | Go | 2026-03-18 | Active | **KEEP** (move K8s/infra bits out) |
+| **e2e** | Cross-service E2E tests + docker-compose | Go | 2026-03-18 | Active | **KEEP** (drop the unused K8s manifests; stays docker-compose-based) |
 | **auth-api** | Intended Auth Service (Go) — but README is verbatim "Go API Template"; looks like an **unmodified bootstrap** | Go | 2025-09-30 | Stale/empty-ish | **KEEP but RESET** — barely started |
 | **jwt-service** | Throwaway: "create a JWT for testing via Firebase", single `jwt.go` | Go | 2026-06-17 | Tiny util | **MERGE → test helpers, then DELETE** |
 | **transactions** | Legacy v0 backend (GORM + Atlas + Fly). Your Makefile style reference | Go | 2024-08 | Stale | **ARCHIVE** |
@@ -37,14 +37,13 @@
 | Proto / contracts | `apis` | ✅ (matches the "Configure Proto Repository" Jira subtask) |
 | Two Postgres DBs (Auth, Core) | inside `auth-api` + `core` | ✅ migrations in sqlc/goose style |
 | Docs | `docs` | ✅ |
-| **Infra / OpenTofu** | **— gap —** | ❌ No infra repo. K8s manifests currently live in `e2e`. |
+| **Infra / OpenTofu** | `infra` | ⚠️ Repo created with the OpenTofu skeleton + CI ([FNS-85](https://loyalt.atlassian.net/browse/FNS-85)); no AWS resources yet (FNS-112/113/114). Unused K8s manifests to be dropped from `e2e` (Fargate, not k8s). |
 | E2E | `e2e` | ✅ |
 
-**One gap remaining:**
+**Both repo gaps now closed; follow-up work remains:**
 
 1. ~~**`core`**~~ — ✅ Being created under [FNS-84](https://loyalt.atlassian.net/browse/FNS-84) (subtasks [FNS-133](https://loyalt.atlassian.net/browse/FNS-133), [FNS-134](https://loyalt.atlassian.net/browse/FNS-134)). `ledger` folding in; archived after.
-2. **`infra`** — OpenTofu/AWS (and any k8s), reusable CI/CD workflows. See [`./aws-architecture.html`](./aws-architecture.html).
-   Move the K8s manifests out of `e2e` into here.
+2. ~~**`infra`**~~ — ✅ Created under [FNS-85](https://loyalt.atlassian.net/browse/FNS-85): OpenTofu skeleton (ECS Fargate per [`./aws-architecture.html`](./aws-architecture.html) §2) + plan/apply CI. Remaining: **drop** the K8s manifests from `e2e` — not relocated, since k8s is no longer a deploy target under the Fargate decision; `e2e` runs on docker-compose, and `infra` can host a full-stack compose for local bring-up. Also consolidate per-repo CI into reusable workflows in `.github`.
 
 ---
 
@@ -70,7 +69,7 @@
 | `auth-api` *(consider rename `auth`)* | Go Auth Service: profiles, JWKs, M2M tokens, ReBAC |
 | `core` | Go modular-monolith Core Service: groups, friends, expenses, settlement, ledger |
 | `apis` | Buf/connectRPC contracts + generated Go/TS clients |
-| `infra` *(new)* | OpenTofu/AWS + k8s + reusable CI/CD workflows |
+| `infra` | OpenTofu/AWS (ECS Fargate) + reusable CI/CD workflows + local-stack docker-compose |
 | `e2e` | Cross-service E2E tests |
 | `docs` | ADRs, roadmap, product spec, diagrams |
 | `.github` | Org profile + shared community-health files |

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-> **Status:** Draft for review · **Last updated:** 2026-06-28
+> **Status:** Draft for review · **Last updated:** 2026-06-29
 >
 > An audit of the `fair-n-square-co` GitHub org: what each repo is for, what's needed, and what to
 > clean up. Companion: [`./delivery-plan.html`](./delivery-plan.html), [`./aws-architecture.html`](./aws-architecture.html).
@@ -23,7 +23,7 @@
 | **app** | Old Flutter mobile bootstrap | Dart | 2024-05-23 | Stale; mobile is post-MVP | **ARCHIVE** |
 | **codecov-login** | Throwaway Codecov OAuth helper, single `main.go` | Go | 2024-04-25 | Dead | **DELETE** |
 | **demo-repository** | GitHub default demo template, never used | HTML | 2024-03-18 | Dead | **DELETE** |
-| **.github** | Org profile **+ reusable CI/CD workflows** (`go-ci`, `codeql`) consumed by service repos via `workflow_call`, versioned `@v1` ([FNS-85](https://loyalt.atlassian.net/browse/FNS-85)) | YAML | 2026-06-28 | Active | **KEEP** — shared CI home; flesh out org README |
+| **.github** | Org profile; **reserved for reusable CD (deploy) workflows** ([FNS-114](https://loyalt.atlassian.net/browse/FNS-114)). CI is owned per-repo, not centralized here. | — | 2026-06-29 | Active | **KEEP** — future CD home; flesh out org README |
 
 ---
 
@@ -43,7 +43,7 @@
 **Both repo gaps now closed; follow-up work remains:**
 
 1. ~~**`core`**~~ — ✅ Being created under [FNS-84](https://loyalt.atlassian.net/browse/FNS-84) (subtasks [FNS-133](https://loyalt.atlassian.net/browse/FNS-133), [FNS-134](https://loyalt.atlassian.net/browse/FNS-134)). `ledger` folding in; archived after.
-2. ~~**`infra`**~~ — ✅ Created under [FNS-85](https://loyalt.atlassian.net/browse/FNS-85): OpenTofu skeleton (ECS Fargate per [`./aws-architecture.html`](./aws-architecture.html) §2) + plan/apply CI. Remaining: **drop** the K8s manifests from `e2e` — not relocated, since k8s is no longer a deploy target under the Fargate decision; `e2e` runs on docker-compose, and `infra` can host a full-stack compose for local bring-up. ✅ Per-repo CI consolidated into reusable workflows in **`.github`** (`go-ci`, `codeql`, referenced `@v1`); `core` is the first adopter.
+2. ~~**`infra`**~~ — ✅ Created under [FNS-85](https://loyalt.atlassian.net/browse/FNS-85): OpenTofu skeleton (ECS Fargate per [`./aws-architecture.html`](./aws-architecture.html) §2) + plan/apply CI. Remaining: **drop** the K8s manifests from `e2e` — not relocated, since k8s is no longer a deploy target under the Fargate decision; `e2e` runs on docker-compose, and `infra` can host a full-stack compose for local bring-up. Service **CI is owned per-repo** (`core` inlines its own lint/build/test/govulncheck/CodeQL, all SHA-pinned); the **`.github`** org repo is reserved for reusable **CD** (deploy) workflows ([FNS-114](https://loyalt.atlassian.net/browse/FNS-114)).
 
 ---
 
@@ -72,7 +72,7 @@
 | `infra` | OpenTofu/AWS (ECS Fargate) + reusable OpenTofu modules + local-stack docker-compose |
 | `e2e` | Cross-service E2E tests |
 | `docs` | ADRs, roadmap, product spec, diagrams |
-| `.github` | Org profile + shared community-health files + **reusable CI/CD workflows** (`go-ci`, `codeql`, `@v1`) |
+| `.github` | Org profile + shared community-health files + **reusable CD (deploy) workflows** (FNS-114; CI is per-repo) |
 
 **Archived (reference only):** `transactions`, `app`, `ledger` (after its code folds into `core`).
 **Deleted:** `web-app`, `jwt-service`, `codecov-login`, `demo-repository`.


### PR DESCRIPTION
Updates `docs/repos.md` now that the `infra` repo exists (FNS-85) and the deploy target is ECS Fargate.

- **§2 mapping table:** `Infra / OpenTofu` row no longer a `— gap —`; points at the `infra` repo (skeleton + CI, no AWS resources yet → FNS-112/113/114).
- **§2 gap list:** both repo gaps (`core`, `infra`) marked closed; remaining follow-ups called out.
- **§1 + §4:** `e2e` no longer lists K8s manifests (being dropped); `infra` final-layout line drops k8s, adds local-stack docker-compose.

Rationale for dropping rather than relocating the manifests matches e2e PR fair-n-square-co/e2e#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AWS architecture docs with shared-service CI guidance using reusable GitHub workflows, including `go-ci` and `codeql` coverage, version pinning practices, third-party action ref-pin behavior, and an initial rollout starting with the core service.
  * Refreshed repository inventory and target-layout documentation, updating audit dates, aligning repo status descriptions, revising architecture gap tracking to indicate core/infra gaps are closed, and documenting remaining follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->